### PR TITLE
Update Bug_ShieldTurret

### DIFF
--- a/Assets/Scripts/Gameplay/Turret/V1/TurretGuns.cs
+++ b/Assets/Scripts/Gameplay/Turret/V1/TurretGuns.cs
@@ -344,6 +344,7 @@ namespace Turret
             }
             _weapons.SetUp(_spawnPointFire);
             _weapons.Reload();
+            _cannonSprite.enabled = true;
             _upperSprite.sprite = _turretData.machineGun.Uppersprites[0];
             _cannonSprite.sprite = _turretData.machineGun.Cannonsprites[0];
         }
@@ -357,6 +358,7 @@ namespace Turret
             }
             _weapons.SetUp(_spawnPointFire);
             _weapons.Reload();
+            _cannonSprite.enabled = true;
             _upperSprite.sprite = _turretData.laserGun.Uppersprites[0];
             _cannonSprite.sprite = _turretData.laserGun.Cannonsprites[0];
         }
@@ -370,6 +372,7 @@ namespace Turret
             }
             _weapons.SetUp(_spawnPointFire);
             _weapons.Reload();
+            _cannonSprite.enabled = true;
             _upperSprite.sprite = _turretData.missileGun.Uppersprites[0];
             _cannonSprite.sprite = _turretData.missileGun.Cannonsprites[0];
         }
@@ -378,6 +381,7 @@ namespace Turret
         {
             _weapons = new EmpGun(_turretData);
             _weapons.SetUp(_spawnPointFire);
+            _cannonSprite.enabled = true;
             _weapons.Reload();
         }
 
@@ -390,6 +394,9 @@ namespace Turret
             }
             _weapons.SetUp(_spawnPointFire);
             _weapons.Reload();
+            _cannonSprite.enabled = false;
+            _cannonHandler.rotation = Quaternion.identity;
+
         }
     }
 


### PR DESCRIPTION
- Fixed issue when the player use different ammo and change to shield, this one keep the previus rotation and mess up how shield showing up.
- Disable now the cannon sprite when use the shield and enable it when use it different ammo.