### PR TITLE
Sound effect bug fixing

### DIFF
--- a/Assets/Prefabs/Enemies/Basic/Enemy_Basic.prefab
+++ b/Assets/Prefabs/Enemies/Basic/Enemy_Basic.prefab
@@ -190,9 +190,9 @@ AudioSource:
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: c21da3880b21b4745bda2913995a7344, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 0.15
+  m_Volume: 0.13
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Prefabs/Enemies/Basic/Enemy_ShieldBasic.prefab
+++ b/Assets/Prefabs/Enemies/Basic/Enemy_ShieldBasic.prefab
@@ -287,7 +287,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 1
-  m_Volume: 0.15
+  m_Volume: 0.13
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Prefabs/Enemies/Giant/Enemy_Giant.prefab
+++ b/Assets/Prefabs/Enemies/Giant/Enemy_Giant.prefab
@@ -273,6 +273,7 @@ MonoBehaviour:
   sr: {fileID: 3276408232143424651}
   Audio: {fileID: 4636537571385478174}
   clip:
+  - {fileID: 8300000, guid: 13254324a99c68348a8cc30dbc64dd74, type: 3}
   - {fileID: 8300000, guid: 47fb0d0dd69b10b4a9062affd5c521a0, type: 3}
   - {fileID: 8300000, guid: 0facb51c4911c2043bec65af376ca949, type: 3}
   deadclip: {fileID: 8300000, guid: 11b3955e811e33d4bad72fe563a0499f, type: 3}

--- a/Assets/Prefabs/Enemies/Giant/Enemy_ShieldGiant.prefab
+++ b/Assets/Prefabs/Enemies/Giant/Enemy_ShieldGiant.prefab
@@ -366,12 +366,11 @@ MonoBehaviour:
   _trainData: {fileID: 11400000, guid: a910442bd209f38429b615fa5f8bf6cb, type: 2}
   _laserHitVFX: {fileID: 4088346475568816580, guid: 580a8120e50668f4aae98cc00e644146,
     type: 3}
-  _giantChargingSFX: {fileID: 2616996482491872489, guid: c8252f4e2f237ae46a6c52a55f613bc3,
-    type: 3}
   enemyData: {fileID: 11400000, guid: 9e44c2d661ac3a242bb84041efc3a1c2, type: 2}
   sr: {fileID: 3276408232143424651}
   Audio: {fileID: 1014029312478659242}
   clip:
+  - {fileID: 8300000, guid: 13254324a99c68348a8cc30dbc64dd74, type: 3}
   - {fileID: 8300000, guid: 47fb0d0dd69b10b4a9062affd5c521a0, type: 3}
   - {fileID: 8300000, guid: 0facb51c4911c2043bec65af376ca949, type: 3}
   deadclip: {fileID: 8300000, guid: 11b3955e811e33d4bad72fe563a0499f, type: 3}

--- a/Assets/Prefabs/Level/Dispensers/Fuel_Dispenser.prefab
+++ b/Assets/Prefabs/Level/Dispensers/Fuel_Dispenser.prefab
@@ -169,8 +169,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _dispenserItem: {fileID: 11400000, guid: 452ae57b267d1cb4684aeef854229fc2, type: 2}
-  _spriteRenderer: {fileID: 7081286187219265533}
-  clip: {fileID: 8300000, guid: 587e20c745283ea47a9de19ae36a9055, type: 3}
+  clip: {fileID: 8300000, guid: b43f6da156fea5443bb37b631cdb3a68, type: 3}
 --- !u!1 &1669809276083957539
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Gameplay/Enemy/Redesign/BasicEnemy.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Redesign/BasicEnemy.cs
@@ -102,7 +102,7 @@ public class BasicEnemy : MonoBehaviour
     }
     private void Start()
     {
-        _audioSource.volume = 0.075f;
+        _audioSource.volume = 0.13f;
     }
     void Update()
     {

--- a/Assets/Scripts/Gameplay/Enemy/Redesign/GiantEnemy.cs
+++ b/Assets/Scripts/Gameplay/Enemy/Redesign/GiantEnemy.cs
@@ -326,7 +326,8 @@ public class GiantEnemy : MonoBehaviour
             {
                 EnableLaserHitVFX();
                 //attack audio
-                Audio.clip = clip[1];
+                Audio.PlayOneShot(clip[1]);
+                Audio.clip = clip[2];
                 Audio.Play();
                 for (int i = 0; i < hit.Length; i++)
                 {

--- a/Assets/Scripts/Gameplay/Train/FadeFuelBar.cs
+++ b/Assets/Scripts/Gameplay/Train/FadeFuelBar.cs
@@ -9,6 +9,7 @@ public class FadeFuelBar : MonoBehaviour
     private SpriteRenderer _spriteRenderer = null;
 
     private bool isFlickering = false;
+    private bool _audioPlayed = false;
     public float gapTime = 0.1f;
     private float tempTime;
 
@@ -42,13 +43,22 @@ public class FadeFuelBar : MonoBehaviour
         tempTime += Time.deltaTime;
         if (_trainData.FuelPercentage < 0.3f)
         {
+            if(!_audioPlayed)
+            {
+                _train.LowFuelAudio.PlayOneShot(_train.LowFuelAudio.clip);
+                _audioPlayed = true;
+            }
             if (tempTime >= gapTime)
             {
                 Flickering();
             }
         }
         else
+        {
+            _audioPlayed = false;
             _spriteRenderer.color = yellow;
+        }
+
     }
 
     public void Flickering()

--- a/Assets/Scripts/Gameplay/Train/Train.cs
+++ b/Assets/Scripts/Gameplay/Train/Train.cs
@@ -18,7 +18,6 @@ namespace GamePlay
         public AudioSource TrainRunningAudio;
         public AudioSource LowFuelAudio;
 
-        private bool _audioPlayed = false;
         private bool _playedEndAnimation = false;
         private float _shakeAmount;
         private Vector3 _pos;
@@ -71,12 +70,6 @@ namespace GamePlay
             // Check how many player has on the scene to increate the FuelRate
             if(LevelManager.Instance.TimeRemaining != LevelManager.Instance.TimeLimit)
                 CurrentFuel(_trainData.FuelRate * (_trainData.PlayerCount / 4.0f) * Time.deltaTime);
-
-            if (_trainData.FuelPercentage < 0.3f && !_audioPlayed)
-            {
-                LowFuelAudio.PlayOneShot(LowFuelAudio.clip);
-                _audioPlayed = true;
-            }
         }
 
         private void ReloadFuel()


### PR DESCRIPTION
-fix fuel dispenser plays wrong audio clip when used by player.
-fix Low fuel alarm sound effect no longer plays after it playing for the first time during a level.
-fix giant enemy attack sound effect
-adjusted basic enemy sound volume.